### PR TITLE
Made TimeSpans still parseable even if server doesn't return millis

### DIFF
--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/utils/TimeUtils.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/utils/TimeUtils.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 public final class TimeUtils {
 
     private static final String FORMAT_TIMESPAN = "%02d.%02d:%02d:%02d.%s";
-    private static final Pattern PATTERN_TIMESPAN = Pattern.compile("(\\d+)?\\.?(\\d{2}):(\\d{2}):(\\d{2})\\.(\\d+)");
+    private static final Pattern PATTERN_TIMESPAN = Pattern.compile("(\\d+)?\\.?(\\d{2}):(\\d{2}):(\\d{2})\\.?(\\d+)?");
     private static final ThreadLocal<DateFormat> DATE_FORMAT = new ThreadLocal<DateFormat>() {
         @Override
         protected DateFormat initialValue() {

--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/utils/TimeUtils.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/utils/TimeUtils.java
@@ -27,7 +27,7 @@ public final class TimeUtils {
     };
 
     private static final String SUFFIX_TIMEZONE = "Z";
-    private static final String SUFFIX_TIMEZONE_MS = ".000Z";
+    private static final String SUFFIX_TIMEZONE_MS = ".000" + SUFFIX_TIMEZONE;
 
     private static final int GROUP_DAYS = 1;
     private static final int GROUP_HOURS = 2;

--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/utils/TimeUtils.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/utils/TimeUtils.java
@@ -26,6 +26,9 @@ public final class TimeUtils {
         }
     };
 
+    private static final String SUFFIX_TIMEZONE = "Z";
+    private static final String SUFFIX_TIMEZONE_MS = ".000Z";
+
     private static final int GROUP_DAYS = 1;
     private static final int GROUP_HOURS = 2;
     private static final int GROUP_MINS = 3;
@@ -136,7 +139,10 @@ public final class TimeUtils {
         if (timestamp == null || timestamp.length() == 0)
             return null;
 
-        timestamp = timestamp.replaceFirst("\\+.*", "Z");
+        timestamp = timestamp.replaceFirst("\\+.*", SUFFIX_TIMEZONE);
+        if (!timestamp.contains(".")) {
+            timestamp = timestamp.replaceFirst(SUFFIX_TIMEZONE, SUFFIX_TIMEZONE_MS);
+        }
 
         try {
             return DATE_FORMAT.get().parse(timestamp).getTime();

--- a/mojio-sdk-model/src/test/java/io/moj/java/sdk/utils/TimeUtilsTest.java
+++ b/mojio-sdk-model/src/test/java/io/moj/java/sdk/utils/TimeUtilsTest.java
@@ -112,6 +112,17 @@ public class TimeUtilsTest {
     }
 
     @Test
+    public void testConvertTimestampToMillis_noMillis() {
+        assertThat(TimeUtils.convertTimestampToMillis("1970-01-01T00:00:00Z")).isEqualTo(0L);
+        assertThat(TimeUtils.convertTimestampToMillis("2016-03-19T00:35:16Z")).isEqualTo(1458347716000L);
+    }
+
+    @Test
+    public void testConvertTimestampToMillis_noMillis_invalidSuffix() {
+        assertThat(TimeUtils.convertTimestampToMillis("2016-03-19T00:35:16+00:00")).isEqualTo(1458347716000L);
+    }
+
+    @Test
     public void testConvertTimestampToMillis_null() {
         assertThat(TimeUtils.convertTimestampToMillis(null)).isNull();
     }

--- a/mojio-sdk-model/src/test/java/io/moj/java/sdk/utils/TimeUtilsTest.java
+++ b/mojio-sdk-model/src/test/java/io/moj/java/sdk/utils/TimeUtilsTest.java
@@ -56,6 +56,24 @@ public class TimeUtilsTest {
         );
     }
 
+    /**
+     * Assert a timespan is still parseable even if milliseconds are not included.
+     */
+    @Test
+    public void testConvertTimespanToMillis_noMillis() {
+        assertThat(TimeUtils.convertTimespanToMillis("00:00:00")).isEqualTo(0);
+
+        assertThat(TimeUtils.convertTimespanToMillis("01:00:00")).isEqualTo(HOURS_TO_MS);
+        assertThat(TimeUtils.convertTimespanToMillis("00:01:00")).isEqualTo(MINUTES_TO_MS);
+        assertThat(TimeUtils.convertTimespanToMillis("00:00:01")).isEqualTo(SECONDS_TO_MS);
+
+        assertThat(TimeUtils.convertTimespanToMillis("02:03:04")).isEqualTo(
+                HOURS_TO_MS * 2 +
+                MINUTES_TO_MS * 3 +
+                SECONDS_TO_MS * 4
+        );
+    }
+
     @Test
     public void testConvertTimespanToMillis_null() {
         assertThat(TimeUtils.convertTimespanToMillis(null)).isNull();


### PR DESCRIPTION
Ran into an issue where some Trip.Duration values from the server aren't returning with millisecond values. While this should probably be fixed server-side (opened PT-163), it's an easy change to let the SDK handle it properly.