### PR TITLE
Added $ to query parameters

### DIFF
--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/Query.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/Query.java
@@ -8,11 +8,11 @@ import java.util.HashMap;
  */
 public class Query extends HashMap<String, String> {
 
-    public static final String TOP = "top";
-    public static final String SKIP = "skip";
-    public static final String FILTER = "filter";
-    public static final String SELECT = "select";
-    public static final String ORDER_BY = "orderby";
+    public static final String TOP = "$top";
+    public static final String SKIP = "$skip";
+    public static final String FILTER = "$filter";
+    public static final String SELECT = "$select";
+    public static final String ORDER_BY = "$orderby";
 
     /**
      * The maximum number of records to return.

--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/logging/LoggingInterceptor.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/logging/LoggingInterceptor.java
@@ -26,7 +26,15 @@ public class LoggingInterceptor implements Interceptor {
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
-        String endpointSignature = "[" + request.method() + " " + request.url().encodedPath() + "]";
+
+        String query = request.url().encodedQuery();
+        if (query == null || query.isEmpty()) {
+            query = "";
+        } else {
+            query = "?" + query;
+        }
+
+        String endpointSignature = "[" + request.method() + " " + request.url().encodedPath() + query + "]";
         String requestMessage = "Request " + endpointSignature;
         if (request.body() != null) {
             try {


### PR DESCRIPTION
Apparently our API's pagination parameters follow the OData specification and require a dollar sign in front..

Platform indicated this may change in the future but for now they are necessary to work.