### PR TITLE
Fixed GET Observer responses

### DIFF
--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/MojioPushApi.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/MojioPushApi.java
@@ -28,7 +28,7 @@ public interface MojioPushApi {
      * @see io.moj.java.sdk.Resource#getPath()
      */
     @GET("{resource}")
-    Call<ListResponse<Observer>> getObservers(@Path("resource") String resource);
+    Call<Observer[]> getObservers(@Path("resource") String resource);
 
     /**
      * Creates an observer for the specified resource(s). Note: only
@@ -133,7 +133,7 @@ public interface MojioPushApi {
      * @return
      */
     @GET("{resource}/{key}/transports")
-    Call<ListResponse<Transport>> getTransports(@Path("resource") String resource, @Path("key") String key);
+    Call<Transport[]> getTransports(@Path("resource") String resource, @Path("key") String key);
 
     /**
      * Adds or updates a transport to an observer.


### PR DESCRIPTION
Updated all MojioPushApi endpoints to return Observer[] and Transport[] instead of ListResponse<> to match actual responses