### PR TITLE
First WebSocket integration of nv-websocket-client

### DIFF
--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/Environment.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/Environment.java
@@ -18,6 +18,10 @@ public interface Environment {
 
     String getPushUrl(int version);
 
+    String getWsUrl();
+
+    String getWsUrl(int version);
+
     String getMyMojioUrl();
 
     String getPrefix();

--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/MojioEnvironment.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/MojioEnvironment.java
@@ -17,11 +17,13 @@ public enum MojioEnvironment implements Environment {
     LOAD("load");
 
     private static final int DEFAULT_VERSION = 2;
-    private static final String SCHEME = "https://";
-    private static final String FORMAT_ACCOUNTS_HOSTNAME = SCHEME + "%saccounts.moj.io";
-    private static final String FORMAT_MY_MOJIO_HOSTNAME = SCHEME + "%smy.moj.io";
-    private static final String FORMAT_API_HOSTNAME = SCHEME + "%sapi.moj.io/v%d";
-    private static final String FORMAT_PUSH_HOSTNAME = SCHEME + "%spush.moj.io/v%d";
+    private static final String HTTPS = "https://";
+    private static final String WSS = "wss://";
+    private static final String FORMAT_ACCOUNTS_HOSTNAME = HTTPS + "%saccounts.moj.io";
+    private static final String FORMAT_MY_MOJIO_HOSTNAME = HTTPS + "%smy.moj.io";
+    private static final String FORMAT_HTTPS_API_HOSTNAME = HTTPS + "%sapi.moj.io/v%d";
+    private static final String FORMAT_WSS_API_HOSTNAME = WSS + "%sapi.moj.io/v%d";
+    private static final String FORMAT_PUSH_HOSTNAME = HTTPS + "%spush.moj.io/v%d";
     private static final String PATH_FORGOT_PASSWORD = "/account/forgot-password";
 
     private static final Map<String, MojioEnvironment> PREFIX_MAP;
@@ -55,7 +57,7 @@ public enum MojioEnvironment implements Environment {
 
     @Override
     public String getApiUrl(int version) {
-        return String.format(Locale.US, FORMAT_API_HOSTNAME, buildUrlPrefix(), version);
+        return String.format(Locale.US, FORMAT_HTTPS_API_HOSTNAME, buildUrlPrefix(), version);
     }
 
     @Override
@@ -71,6 +73,16 @@ public enum MojioEnvironment implements Environment {
     @Override
     public String getMyMojioUrl() {
         return String.format(Locale.US, FORMAT_MY_MOJIO_HOSTNAME, buildUrlPrefix());
+    }
+
+    @Override
+    public String getWsUrl() {
+        return getWsUrl(DEFAULT_VERSION);
+    }
+
+    @Override
+    public String getWsUrl(int version) {
+        return String.format(Locale.US, FORMAT_WSS_API_HOSTNAME, buildUrlPrefix(), version);
     }
 
     @Override

--- a/mojio-sdk-rest/build.gradle
+++ b/mojio-sdk-rest/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     def retrofitVersion = '2.1.0'
     compile "com.squareup.retrofit2:retrofit:${retrofitVersion}"
     compile "com.squareup.retrofit2:converter-gson:${retrofitVersion}"
+    compile 'com.neovisionaries:nv-websocket-client:1.31'
 
     testCompile 'junit:junit:4.12'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.2.0'

--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/MojioClient.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/MojioClient.java
@@ -494,7 +494,6 @@ public class MojioClient {
                 AccessToken accessToken = new AccessToken(authResponse.getAccessToken(), authResponse.getRefreshToken(),
                         startTime + TimeUnit.SECONDS.toMillis(authResponse.getExpiresIn()));
                 authenticator.setAccessToken(accessToken);
-                ((MojioWebSocket) wsApi).setAccessToken();
                 return true;
             }
             return false;

--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/MojioClient.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/MojioClient.java
@@ -13,9 +13,11 @@ import io.moj.java.sdk.auth.Authenticator;
 import io.moj.java.sdk.auth.Client;
 import io.moj.java.sdk.auth.DefaultAuthenticator;
 import io.moj.java.sdk.auth.OnAccessTokenExpiredListener;
+import io.moj.java.sdk.logging.Log;
 import io.moj.java.sdk.logging.LoggingInterceptor;
 import io.moj.java.sdk.model.User;
 import io.moj.java.sdk.model.response.AuthResponse;
+import io.moj.java.sdk.websocket.MojioWebSocket;
 import okhttp3.Dispatcher;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
@@ -45,6 +47,7 @@ public class MojioClient {
     private MojioRestApi restApi;
     private MojioAuthApi authApi;
     private MojioPushApi pushApi;
+    private MojioWebSocket webSocket;
     private MojioStorageApi storageApi;
     private Authenticator authenticator;
     private AuthInterceptor authInterceptor;
@@ -108,6 +111,12 @@ public class MojioClient {
         retrofitBuilder.client(httpClients[1]);
 
         initAuthenticatedApis(retrofitBuilder);
+
+        webSocket = new MojioWebSocket(this.environment.getWsUrl() + "/");
+
+//        if (this.authenticator.getAccessToken() != null) {
+//            webSocket.setAccessToken(this.authenticator.getAccessToken().getAccessToken());
+//        }
     }
 
     protected void initAuthenticatedApis(Retrofit.Builder retrofitBuilder) {
@@ -178,6 +187,8 @@ public class MojioClient {
     public MojioStorageApi storage() {
         return storageApi;
     }
+
+    public MojioWebSocket webSocket() { return webSocket; }
 
     /**
      * Returns the client's configured environment.
@@ -487,6 +498,7 @@ public class MojioClient {
                 AccessToken accessToken = new AccessToken(authResponse.getAccessToken(), authResponse.getRefreshToken(),
                         startTime + TimeUnit.SECONDS.toMillis(authResponse.getExpiresIn()));
                 authenticator.setAccessToken(accessToken);
+                webSocket.setAccessToken(accessToken.getAccessToken());
                 return true;
             }
             return false;

--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/websocket/MojioWebSocket.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/websocket/MojioWebSocket.java
@@ -2,8 +2,10 @@ package io.moj.java.sdk.websocket;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 
 import com.neovisionaries.ws.client.WebSocket;
+import com.neovisionaries.ws.client.WebSocketException;
 import com.neovisionaries.ws.client.WebSocketFactory;
 import com.neovisionaries.ws.client.WebSocketState;
 
@@ -16,7 +18,7 @@ import io.moj.java.sdk.auth.Authenticator;
 
 public class MojioWebSocket implements MojioWebSocketApi {
     private WebSocketFactory factory;
-    private HashMap<MojioWebSocketListener, WebSocket> listenerWebSocketMap;
+    private Map<MojioWebSocketListener, WebSocket> listenerWebSocketMap;
     private String baseUrl;
     private Authenticator authenticator;
     private String accessToken;
@@ -26,27 +28,26 @@ public class MojioWebSocket implements MojioWebSocketApi {
         listenerWebSocketMap = new HashMap<>();
         this.baseUrl = baseUrl;
         this.authenticator = authenticator;
-        setAccessToken();
     }
 
     @Override
     public void getVehicle(String id, MojioWebSocketListener listener) throws IOException {
-        connect(baseUrl + "/vehicles/" + id, listener);
+        setup(baseUrl + "/vehicles/" + id, listener);
     }
 
     @Override
     public void getVehicles(MojioWebSocketListener listener) throws IOException {
-        connect(baseUrl + "/vehicles", listener);
+        setup(baseUrl + "/vehicles", listener);
     }
 
     @Override
     public void getMojio(String id, MojioWebSocketListener listener) throws IOException {
-        connect(baseUrl + "/mojios/" + id, listener);
+        setup(baseUrl + "/mojios/" + id, listener);
     }
 
     @Override
     public void getMojios(MojioWebSocketListener listener) throws IOException {
-        connect(baseUrl + "/mojios", listener);
+        setup(baseUrl + "/mojios", listener);
     }
 
     @Override
@@ -60,26 +61,18 @@ public class MojioWebSocket implements MojioWebSocketApi {
         }
     }
 
-    public void setAccessToken() {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                if (authenticator.getAccessToken() != null) {
-                    accessToken = "Bearer " + authenticator.getAccessToken().getAccessToken();
-                }
-            }
-        }).start();
-    }
-
-    private void connect(String url, MojioWebSocketListener listener) throws IOException {
+    private void setup(String url, MojioWebSocketListener listener) throws IOException {
         WebSocket ws = getSocket(url);
         if (ws == null) {
             // Create a new WebSocket only if one isn't already open.
             ws = factory.createSocket(url);
-            ws.addHeader("Authorization", accessToken);
-            ws.connectAsynchronously();
+            connect(ws);
         } else if (ws.getState() == WebSocketState.CLOSING || ws.getState() == WebSocketState.CLOSED) {
-            ws.recreate().connectAsynchronously();
+            WebSocket newWs = ws.recreate();
+            newWs.clearHeaders();
+            connect(ws);
+            updateSocketMap(ws, newWs);
+            ws = newWs;
         }
 
         // Check if this is an existing listener. If yes, check for the attached WebSocket. If that's
@@ -92,6 +85,23 @@ public class MojioWebSocket implements MojioWebSocketApi {
         }
     }
 
+    private void connect(final WebSocket webSocket) {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                if (authenticator.getAccessToken() != null) {
+                    accessToken = "Bearer " + authenticator.getAccessToken().getAccessToken();
+                    webSocket.addHeader("Authorization", accessToken);
+                    try {
+                        webSocket.connect();
+                    } catch (WebSocketException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }).start();
+    }
+
     private WebSocket getSocket(String url) {
         for (WebSocket ws : listenerWebSocketMap.values()) {
             if (ws.getURI().toString().equalsIgnoreCase(url)) {
@@ -99,5 +109,18 @@ public class MojioWebSocket implements MojioWebSocketApi {
             }
         }
         return null;
+    }
+
+    /**
+     * Replacing all old WebSocket associated with listeners with the new one
+     * @param oldWebSocket
+     * @param newWebSocket
+     */
+    private void updateSocketMap(WebSocket oldWebSocket, WebSocket newWebSocket) {
+        for (MojioWebSocketListener listener : listenerWebSocketMap.keySet()) {
+            if (listenerWebSocketMap.get(listener) == oldWebSocket) {
+                listenerWebSocketMap.put(listener, newWebSocket);
+            }
+        }
     }
 }

--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/websocket/MojioWebSocket.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/websocket/MojioWebSocket.java
@@ -1,0 +1,86 @@
+package io.moj.java.sdk.websocket;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import com.neovisionaries.ws.client.WebSocket;
+import com.neovisionaries.ws.client.WebSocketFactory;
+
+import io.moj.java.sdk.logging.Log;
+
+/**
+ * Created by alexc on 2017-04-25.
+ */
+
+public class MojioWebSocket {
+    private static WebSocketFactory factory;
+    private String baseUrl;
+    private String accessToken;
+    private HashMap<MojioWebSocketListener, WebSocket> listenerWebSocketMap = new HashMap<>();
+
+    public MojioWebSocket(String baseUrl) {
+        if (factory == null) {
+            factory = new WebSocketFactory();
+            this.baseUrl = baseUrl;
+        }
+    }
+
+    public void setAccessToken(String token) {
+        accessToken = "Bearer " + token;
+    }
+
+    public void connect(String suffix, MojioWebSocketListener listener) throws IOException {
+        String url = baseUrl + suffix;
+        WebSocket ws = getSocket(url);
+
+
+        if (ws == null) {
+            ws = factory.createSocket(url);
+            ws.addHeader("Authorization", accessToken);
+            Log.d("Alex", url + ", " + accessToken);
+            ws.connectAsynchronously();
+        }
+
+        ws.addListener(listener);
+        listenerWebSocketMap.put(listener, ws);
+    }
+
+    public void disconnect(MojioWebSocketListener listener) {
+        WebSocket ws = listenerWebSocketMap.remove(listener);
+        if (ws != null) {
+            ws.removeListener(listener);
+            if (!listenerWebSocketMap.containsValue(ws)) {
+                ws.disconnect();
+            }
+        }
+    }
+
+//    public void getVehicle(String id, MojioWebSocketListener listener) throws IOException {
+//        String url = baseUrl + "vehicle/" + id;
+//        connect(url, listener);
+//    }
+//
+//    public void getVehicles(MojioWebSocketListener listener) throws IOException {
+//        String url = baseUrl + "vehicles";
+//        connect(url, listener);
+//    }
+//
+//    public void getMojio(String id, MojioWebSocketListener listener) throws IOException {
+//        String url = baseUrl + "mojio/" + id;
+//        connect(url, listener);
+//    }
+//
+//    public void getMojios(MojioWebSocketListener listener) throws IOException {
+//        String url = baseUrl + "mojios";
+//        connect(url, listener);
+//    }
+
+    private WebSocket getSocket(String url) {
+        for (WebSocket ws : listenerWebSocketMap.values()) {
+            if (ws.getURI().toString().equalsIgnoreCase(url)) {
+                return ws;
+            }
+        }
+        return null;
+    }
+}

--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/websocket/MojioWebSocket.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/websocket/MojioWebSocket.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.neovisionaries.ws.client.WebSocket;
-import com.neovisionaries.ws.client.WebSocketException;
 import com.neovisionaries.ws.client.WebSocketFactory;
 import com.neovisionaries.ws.client.WebSocketState;
 
@@ -92,11 +91,7 @@ public class MojioWebSocket implements MojioWebSocketApi {
                 if (authenticator.getAccessToken() != null) {
                     accessToken = "Bearer " + authenticator.getAccessToken().getAccessToken();
                     webSocket.addHeader("Authorization", accessToken);
-                    try {
-                        webSocket.connect();
-                    } catch (WebSocketException e) {
-                        e.printStackTrace();
-                    }
+                    webSocket.connectAsynchronously();
                 }
             }
         }).start();

--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/websocket/MojioWebSocketApi.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/websocket/MojioWebSocketApi.java
@@ -1,0 +1,21 @@
+package io.moj.java.sdk.websocket;
+
+import java.io.IOException;
+
+/**
+ * Mojio WebSocket API
+ * Created by alexc on 2017-05-01.
+ */
+
+public interface MojioWebSocketApi {
+
+    void getVehicles(MojioWebSocketListener listener) throws IOException;
+
+    void getVehicle(String id, MojioWebSocketListener listener) throws IOException;
+
+    void getMojios(MojioWebSocketListener listener) throws IOException;
+
+    void getMojio(String id, MojioWebSocketListener listener) throws IOException;
+
+    void removeListener(MojioWebSocketListener listener);
+}

--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/websocket/MojioWebSocketListener.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/websocket/MojioWebSocketListener.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
+ * WebSocket listener class. Note that these methods will be called on a background thread and not
+ * the main thread.
  * Created by alexc on 2017-04-27.
  */
 

--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/websocket/MojioWebSocketListener.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/websocket/MojioWebSocketListener.java
@@ -1,0 +1,44 @@
+package io.moj.java.sdk.websocket;
+
+import com.neovisionaries.ws.client.WebSocket;
+import com.neovisionaries.ws.client.WebSocketAdapter;
+import com.neovisionaries.ws.client.WebSocketException;
+import com.neovisionaries.ws.client.WebSocketFrame;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by alexc on 2017-04-27.
+ */
+
+public abstract class MojioWebSocketListener extends WebSocketAdapter {
+
+    @Override
+    public void onTextMessage(WebSocket websocket, String text) {
+        onResponse(text);
+    }
+
+    @Override
+    public void onConnected(WebSocket websocket, Map<String, List<String>> headers) throws Exception {
+        onConnected(headers);
+    }
+
+    @Override
+    public void onDisconnected(WebSocket websocket, WebSocketFrame serverCloseFrame, WebSocketFrame clientCloseFrame, boolean closedByServer) throws Exception {
+        onDisconnected();
+    }
+
+    @Override
+    public void onError(WebSocket websocket, WebSocketException cause) throws Exception {
+        onError(cause);
+    }
+
+    abstract public void onResponse(String text);
+
+    abstract public void onConnected(Map<String, List<String>> headers);
+
+    abstract public void onDisconnected();
+
+    abstract public void onError(Exception e);
+}


### PR DESCRIPTION
This provides the basic WebSocket functionality for the Mojio SDK.

Authentication is handled. Mojio client app just needs to call the specific WebSocket API calls to get the 2 primary objects (Vehicles and Mojios) in JSON format.

Error handling is not fully fleshed out. Will be looking into that more if/when Motion Android tries to incorporate WebSocket. The default error handling of nv-websocket-client is of course in place.