### PR TITLE
PA-3616 Reset Password Request Missing Basic Auth Header

### DIFF
--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/MojioAuthApi.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/MojioAuthApi.java
@@ -153,7 +153,7 @@ public interface MojioAuthApi {
             "Content-Type: application/json",
             "Accept: application/json"
     })
-    Call<RegistrationResponse> forgotPassword(@Body ForgotPasswordRequest request);
+    Call<RegistrationResponse> forgotPassword(@Header("Authorization") String auth, @Body ForgotPasswordRequest request);
 
     /**
      * Endpoint for resetting the password


### PR DESCRIPTION
Added missing Auth header for forgotPassword request to obtain correct resetPassword link