### PR TITLE
2019/10/25/remove the word warning

### DIFF
--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/stream/ObjectType.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/stream/ObjectType.java
@@ -15,8 +15,8 @@ public enum ObjectType {
     RECALL("Recall"),
     NOTE("Note"),
     TIRE_PRESSURE("TirePressure"),
-    OIL_LEVEL("OilLevelWarning"),
-    OIL_PRESSURE("OilPressureWarning"),
+    OIL_LEVEL("OilLevel"),
+    OIL_PRESSURE("OilPressure"),
     BATTERY_PREDICTION("BatteryPredictiveMaintenance"),
     AIR_FILTER_PREDICTION("AirFilterPredictiveMaintenance");
 

--- a/mojio-sdk-model/src/test/java/io/moj/java/sdk/model/stream/ObjectTypeTest.java
+++ b/mojio-sdk-model/src/test/java/io/moj/java/sdk/model/stream/ObjectTypeTest.java
@@ -25,8 +25,8 @@ public class ObjectTypeTest extends EnumTest<ObjectType> {
                 .put("Recall", ObjectType.RECALL)
                 .put("Note", ObjectType.NOTE)
                 .put("TirePressure", ObjectType.TIRE_PRESSURE)
-                .put("OilLevelWarning", ObjectType.OIL_LEVEL)
-                .put("OilPressureWarning", ObjectType.OIL_PRESSURE)
+                .put("OilLevel", ObjectType.OIL_LEVEL)
+                .put("OilPressure", ObjectType.OIL_PRESSURE)
                 .put("BatteryPredictiveMaintenance", ObjectType.BATTERY_PREDICTION)
                 .put("AirFilterPredictiveMaintenance", ObjectType.AIR_FILTER_PREDICTION)
                 .build();


### PR DESCRIPTION
Reversing @henrymojio 's previous 2 changes that added Warning when it was Platform team's bug to fix.