### PR TITLE
Feature/mykhaylo/2020/01/tde-2601 Incorrect 'Critically tire pressure alert' screen is getting displayed after tapping on Push Notification

### DIFF
--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/values/DiagnosticCode.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/values/DiagnosticCode.java
@@ -86,6 +86,7 @@ public class DiagnosticCode {
                 ", Severity=" + Severity +
                 ", Instructions='" + Instructions + '\'' +
                 ", Ignored=" + Ignored +
+                ", IsExtraCode=" + false +
                 '}';
     }
 }

--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/values/DiagnosticCode.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/values/DiagnosticCode.java
@@ -86,7 +86,7 @@ public class DiagnosticCode {
                 ", Severity=" + Severity +
                 ", Instructions='" + Instructions + '\'' +
                 ", Ignored=" + Ignored +
-                ", IsExtraCode=" + false +
+                ", IsExtraCode=" + IsExtraCode +
                 '}';
     }
 }

--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/values/DiagnosticCode.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/values/DiagnosticCode.java
@@ -75,7 +75,7 @@ public class DiagnosticCode {
 
     public Boolean getIsExtraCode() { return IsExtraCode; }
 
-    public void setExtraCode(Boolean specialCode) { IsExtraCode = specialCode; }
+    public void setIsExtraCode(Boolean specialCode) { IsExtraCode = specialCode; }
 
     @Override
     public String toString() {

--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/values/DiagnosticCode.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/values/DiagnosticCode.java
@@ -23,6 +23,8 @@ public class DiagnosticCode {
     @SerializedName(value = "Ignored", alternate = "ignored")
     private Boolean Ignored;
 
+    // This flag is used to specify DiagnosticCode generated from received warnings
+    // as they don't have a specific code (e.t. Tire Pressure, Engine Oil)
     private Boolean IsExtraCode = false;
 
     public String getCode() {

--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/values/DiagnosticCode.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/values/DiagnosticCode.java
@@ -23,6 +23,8 @@ public class DiagnosticCode {
     @SerializedName(value = "Ignored", alternate = "ignored")
     private Boolean Ignored;
 
+    private Boolean IsExtraCode = false;
+
     public String getCode() {
         return Code;
     }
@@ -70,6 +72,10 @@ public class DiagnosticCode {
     public void setIgnored(Boolean ignored) {
         Ignored = ignored;
     }
+
+    public Boolean isExtraCode() { return IsExtraCode; }
+
+    public void setExtraCode(Boolean specialCode) { IsExtraCode = specialCode; }
 
     @Override
     public String toString() {

--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/values/DiagnosticCode.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/model/values/DiagnosticCode.java
@@ -73,7 +73,7 @@ public class DiagnosticCode {
         Ignored = ignored;
     }
 
-    public Boolean isExtraCode() { return IsExtraCode; }
+    public Boolean getIsExtraCode() { return IsExtraCode; }
 
     public void setExtraCode(Boolean specialCode) { IsExtraCode = specialCode; }
 


### PR DESCRIPTION
Ticket: TDE-2601 Incorrect 'Critically tire pressure alert' screen is getting displayed after tapping on Push Notification
Added IsExtraCode boolean field into DiagnosticCode. It's not a part of a payload that's why it doesn;t have serialization by name. It will be used locally (Android) to determine if DTC is one of DTC generated in our code (e. t. Oil, Tire...) In such case IsExtraCode = true