### PR TITLE
PA-6284: App logout improvements

### DIFF
--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/MojioPushApi.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/MojioPushApi.java
@@ -96,7 +96,7 @@ public interface MojioPushApi {
      * @return
      */
     @DELETE("{resource}/{key}")
-    Call<MessageResponse> deleteObserver(@Path("resource") String resource, @Path("key") String key);
+    Call<Void> deleteObserver(@Path("resource") String resource, @Path("key") String key);
 
     /**
      * Deletes an observer.

--- a/mojio-sdk-rest/src/main/java/io/moj/java/sdk/auth/AuthInterceptor.java
+++ b/mojio-sdk-rest/src/main/java/io/moj/java/sdk/auth/AuthInterceptor.java
@@ -30,11 +30,13 @@ public class AuthInterceptor implements Interceptor {
         Request request = chain.request();
 
         // set the access token in the header if we have it
-        AccessToken accessToken = authenticator.getAccessToken();
-        Request.Builder requestBuilder = request.newBuilder();
-        if (accessToken != null) {
-            requestBuilder.header("Authorization", "Bearer " + accessToken.getAccessToken());
+        AccessToken accessToken = authenticator.getAccessToken(); // this is a blocking call.
+        if (accessToken == null || accessToken.getAccessToken() == null) {
+            throw new IOException(new Throwable("No access token."));
         }
+
+        Request.Builder requestBuilder = request.newBuilder();
+        requestBuilder.header("Authorization", "Bearer " + accessToken.getAccessToken());
         requestBuilder.addHeader("Content-Type", "application/json");
         requestBuilder.addHeader("Accept", "application/json");
         request = requestBuilder.build();

--- a/mojio-sdk-rest/src/test/java/io/moj/java/sdk/MojioClientTest.java
+++ b/mojio-sdk-rest/src/test/java/io/moj/java/sdk/MojioClientTest.java
@@ -117,6 +117,8 @@ public class MojioClientTest {
         when(environment.getApiUrl(1)).thenReturn(serverUrl);
         when(environment.getPushUrl()).thenReturn(serverUrl);
         when(environment.getAccountsUrl()).thenReturn(serverUrl);
+        AccessToken token = new AccessToken("expectedAuthToken", null, System.currentTimeMillis() + 120_000);
+        when(mockAuthenticator.getAccessToken()).thenReturn(token);
 
         Interceptor mockInterceptor = mock(Interceptor.class);
         when(mockInterceptor.intercept((any(Interceptor.Chain.class)))).thenAnswer(new Answer<okhttp3.Response>() {

--- a/mojio-sdk-rest/src/test/java/io/moj/java/sdk/auth/AuthInterceptorTest.java
+++ b/mojio-sdk-rest/src/test/java/io/moj/java/sdk/auth/AuthInterceptorTest.java
@@ -50,16 +50,12 @@ public class AuthInterceptorTest {
         Log.append(logger);
     }
 
-    @Test
+    @Test(expected = IOException.class)
     public void testIntercept_noAccount_ok() throws IOException {
         int expectedCode = 200;
         Mock mock = mockChain(expectedCode);
 
         Response actualResponse = interceptor.intercept(mock.chain);
-        assertThat(actualResponse).isEqualTo(mock.response);
-
-        // verify we did not trigger the OnAccessTokenExpiredListener
-        verify(listener, never()).onAccessTokenExpired();
     }
 
     @Test

--- a/mojio-sdk-rest/src/test/java/io/moj/java/sdk/rest/GetTripSpeedingViolationTest.java
+++ b/mojio-sdk-rest/src/test/java/io/moj/java/sdk/rest/GetTripSpeedingViolationTest.java
@@ -5,6 +5,8 @@ import io.moj.java.sdk.MojioClient;
 import io.moj.java.sdk.MojioRestApi;
 import io.moj.java.sdk.model.enums.SpeedUnit;
 import io.moj.java.sdk.model.values.SpeedingViolation;
+import io.moj.java.sdk.auth.AccessToken;
+import io.moj.java.sdk.auth.Authenticator;
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.After;
@@ -19,6 +21,7 @@ import java.util.List;
 import static com.google.common.truth.Truth.assertThat;
 import static io.moj.java.sdk.test.utils.MockWebServerUtils.successFromFile;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 
 public class GetTripSpeedingViolationTest {
     private MockWebServer mockWebServer = new MockWebServer();
@@ -89,9 +92,13 @@ public class GetTripSpeedingViolationTest {
     @Before
     public void setUp() {
         Environment environment = getMockedEnvironment();
+        Authenticator mockAuthenticator = mock(Authenticator.class);
+        AccessToken token = new AccessToken("expectedAuthToken", null, System.currentTimeMillis() + 120_000);
+        when(mockAuthenticator.getAccessToken()).thenReturn(token);
 
         MojioClient client = new MojioClient.Builder("any", "any")
                 .environment(environment)
+                .authenticator(mockAuthenticator)
                 .build();
 
         restApi = client.rest();


### PR DESCRIPTION
Since all requests using AuthInterceptor should have an access token, we should be throwing an Exception if there is none. This short-circuits the process so we don't put requests in a queue and wait to be rejected at a much later time. This one change allows for more efficient implementation of application.

Also found that an Exception is thrown even when deleteObserver is called correctly. Turns out we're trying to parse the response body when there is no response body.

Fixed unit tests based on the AuthInterceptor changes.