### PR TITLE
Removing my.moj.io as it's not used anywhere anymore.

### DIFF
--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/Environment.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/Environment.java
@@ -22,8 +22,6 @@ public interface Environment {
 
     String getWsUrl(int version);
 
-    String getMyMojioUrl();
-
     String getPrefix();
 
 }

--- a/mojio-sdk-model/src/main/java/io/moj/java/sdk/MojioEnvironment.java
+++ b/mojio-sdk-model/src/main/java/io/moj/java/sdk/MojioEnvironment.java
@@ -21,7 +21,6 @@ public enum MojioEnvironment implements Environment {
     private static final String HTTPS = "https://";
     private static final String WSS = "wss://";
     private static final String FORMAT_ACCOUNTS_HOSTNAME = HTTPS + "%saccounts.moj.io";
-    private static final String FORMAT_MY_MOJIO_HOSTNAME = HTTPS + "%smy.moj.io";
     private static final String FORMAT_HTTPS_API_HOSTNAME = HTTPS + "%sapi.moj.io/v%d";
     private static final String FORMAT_WSS_API_HOSTNAME = WSS + "%sapi.moj.io/v%d";
     private static final String FORMAT_PUSH_HOSTNAME = HTTPS + "%spush.moj.io/v%d";
@@ -69,11 +68,6 @@ public enum MojioEnvironment implements Environment {
     @Override
     public String getPushUrl(int version) {
         return String.format(Locale.US, FORMAT_PUSH_HOSTNAME, buildUrlPrefix(), version);
-    }
-
-    @Override
-    public String getMyMojioUrl() {
-        return String.format(Locale.US, FORMAT_MY_MOJIO_HOSTNAME, buildUrlPrefix());
     }
 
     @Override

--- a/mojio-sdk-model/src/test/java/io/moj/java/sdk/MojioEnvironmentTest.java
+++ b/mojio-sdk-model/src/test/java/io/moj/java/sdk/MojioEnvironmentTest.java
@@ -23,7 +23,6 @@ public class MojioEnvironmentTest {
         String pushUrl = e.getPushUrl();
         String accountsUrl = e.getAccountsUrl();
         String passwordRecoveryUrl = e.getPasswordRecoveryUrl();
-        String myMojioUrl = e.getMyMojioUrl();
 
         // Turkey's Locale is known for affecting capitalization, ensure we aren't using the default
         Locale.setDefault(new Locale("tr-TR"));
@@ -31,7 +30,6 @@ public class MojioEnvironmentTest {
         assertThat(pushUrl).isEqualTo(e.getPushUrl());
         assertThat(accountsUrl).isEqualTo(e.getAccountsUrl());
         assertThat(passwordRecoveryUrl).isEqualTo(e.getPasswordRecoveryUrl());
-        assertThat(myMojioUrl).isEqualTo(e.getMyMojioUrl());
     }
 
     /**
@@ -44,7 +42,6 @@ public class MojioEnvironmentTest {
 
             String[] uris = new String[] {
                     environment.getAccountsUrl(),
-                    environment.getMyMojioUrl(),
                     environment.getPasswordRecoveryUrl(),
                     environment.getPushUrl(),
                     environment.getApiUrl()


### PR DESCRIPTION
Confirmed with our platform team that my.moj.io is not used in app or by any other 3rd party app developer.

The only relevance for us is the OBD locator helper URL, which we hardcode in our config.xml.